### PR TITLE
chore(deps): upgrade lru-cache dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ function hash(object) {
   }));
 }
 
-var cache = (0, _lruCache2.default)(100);
+var cache = new _lruCache2.default({ max: 100 });
 
 function validate(anArrayOfKeys) {
   var moduleOutputPrefix = '[keykey]';

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "mocha": "2.3.4"
   },
   "dependencies": {
-    "lru-cache": "3.2.0"
+    "lru-cache": "^5.1.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ function hash (object) {
         }))
 }
 
-const cache = LRU(100)
+const cache = new LRU({ max: 100 })
 
 function validate (anArrayOfKeys) {
   const moduleOutputPrefix = '[keykey]';


### PR DESCRIPTION
Many packages have upgraded to `lru-cache` v5+.  Using said packages alongside `keykey` causes `keykey` to error because of incorrect instantiation of the LRU cache.  This PR aims to fix that.